### PR TITLE
Lesson 6: Accessibility in React

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,9 @@ import { useState } from 'react';
 import { nanoid } from 'nanoid';
 import { FILTER_MAP } from './lib/filter';
 import type { FilterName } from './lib/filter';
+import { useRef } from 'react';
+import { usePrevious } from './hooks/usePrevious';
+import { useEffect } from 'react';
 
 type Props = {
   tasks: Task[];
@@ -60,6 +63,17 @@ function App(props: Props) {
     setTasks(editedTasks);
   }
 
+  // ===== for focus control =====
+  const listHeadingRef = useRef<HTMLHeadingElement>(null);
+
+  const prevTaskLength = usePrevious<number>(tasks.length);
+
+  useEffect(() => {
+    if (prevTaskLength !== undefined && tasks.length - prevTaskLength === -1) {
+      listHeadingRef.current?.focus();
+    }
+  }, [prevTaskLength, tasks.length]);
+
   // ===== inner templates =====
   const taskList = tasks
     .filter(FILTER_MAP[filter])
@@ -88,7 +102,9 @@ function App(props: Props) {
       <h1>TodoMatic</h1>
       <Form addTask={addTask} />
       <div className='filters btn-group stack-exception'>{filterList}</div>
-      <h2 id='list-heading'>{headingText}</h2>
+      <h2 id='list-heading' tabIndex={-1} ref={listHeadingRef}>
+        {headingText}
+      </h2>
       {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
       <ul role='list' className='todo-list stack-large stack-exception' aria-labelledby='list-heading'>
         {taskList}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,9 @@ type Props = {
 
 function App(props: Props) {
   const [tasks, setTasks] = useState(props.tasks);
+  const [filter, setFilter] = useState<FilterName>('all');
 
+  // ===== task control methods =====
   function addTask(name: string) {
     const newTask = {
       name,
@@ -58,8 +60,7 @@ function App(props: Props) {
     setTasks(editedTasks);
   }
 
-  const [filter, setFilter] = useState<FilterName>('all');
-
+  // ===== inner templates =====
   const taskList = tasks
     .filter(FILTER_MAP[filter])
     .map((task) => (

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -1,6 +1,17 @@
 import type { ChangeEvent, FC, FormEvent } from 'react';
+import { useEffect } from 'react';
+import { useRef } from 'react';
 import { useState } from 'react';
 import type { Task } from '../types/Task';
+
+function usePrevious(value: boolean) {
+  const ref = useRef<boolean>();
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}
 
 type Props = Task & {
   toggleTaskCompleted: (id: string) => void;
@@ -27,13 +38,35 @@ const Todo: FC<Props> = (props) => {
     setIsEditing(false);
   }
 
+  const editFieldRef = useRef<HTMLInputElement>(null);
+  const editButtonRef = useRef<HTMLButtonElement>(null);
+
+  console.log(isEditing);
+  const wasEditingBefore = usePrevious(isEditing);
+
+  useEffect(() => {
+    console.log(wasEditingBefore);
+    if (isEditing) {
+      editFieldRef.current?.focus();
+    } else if (wasEditingBefore) {
+      editButtonRef.current?.focus();
+    }
+  }, [isEditing, wasEditingBefore]);
+
   const editingTemplate = (
     <form className='stack-small' onSubmit={handleSubmit}>
       <div className='form-group'>
         <label className='todo-label' htmlFor={props.id}>
           New name for {props.name}
         </label>
-        <input id={props.id} className='todo-text' type='text' value={newName} onChange={handleChange} />
+        <input
+          id={props.id}
+          className='todo-text'
+          type='text'
+          value={newName}
+          onChange={handleChange}
+          ref={editFieldRef}
+        />
       </div>
       <div className='btn-group'>
         <button type='button' className='btn todo-cancel' onClick={() => cancelEditing()}>
@@ -61,7 +94,7 @@ const Todo: FC<Props> = (props) => {
         </label>
       </div>
       <div className='btn-group'>
-        <button type='button' className='btn' onClick={() => setIsEditing(true)}>
+        <button type='button' className='btn' onClick={() => setIsEditing(true)} ref={editButtonRef}>
           Edit <span className='visually-hidden'>{props.name}</span>
         </button>
         <button type='button' className='btn btn__danger' onClick={() => props.deleteTask(props.id)}>

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -2,16 +2,8 @@ import type { ChangeEvent, FC, FormEvent } from 'react';
 import { useEffect } from 'react';
 import { useRef } from 'react';
 import { useState } from 'react';
+import { usePrevious } from '../hooks/usePrevious';
 import type { Task } from '../types/Task';
-
-function usePrevious(value: boolean) {
-  const ref = useRef<boolean>();
-  useEffect(() => {
-    ref.current = value;
-  }, [value]);
-
-  return ref.current;
-}
 
 type Props = Task & {
   toggleTaskCompleted: (id: string) => void;
@@ -42,7 +34,7 @@ const Todo: FC<Props> = (props) => {
   const editButtonRef = useRef<HTMLButtonElement>(null);
 
   console.log(isEditing);
-  const wasEditingBefore = usePrevious(isEditing);
+  const wasEditingBefore = usePrevious<boolean>(isEditing);
 
   useEffect(() => {
     console.log(wasEditingBefore);

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -33,11 +33,9 @@ const Todo: FC<Props> = (props) => {
   const editFieldRef = useRef<HTMLInputElement>(null);
   const editButtonRef = useRef<HTMLButtonElement>(null);
 
-  console.log(isEditing);
   const wasEditingBefore = usePrevious<boolean>(isEditing);
 
   useEffect(() => {
-    console.log(wasEditingBefore);
     if (isEditing) {
       editFieldRef.current?.focus();
     } else if (wasEditingBefore) {

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,0 +1,10 @@
+import { useEffect, useRef } from 'react';
+
+export function usePrevious<T>(value: T) {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}


### PR DESCRIPTION
### URL
https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_accessibility

## 内容
- 動的なレンダリングの影響でフォーカスしていたコンポーネントがアンマウントされたとき、`ref` で望ましい要素に `focus` する等。
- useState の前の値を取得する `usePrevious` hook の作成・使用。

## 感想
このレッスンは、WAI-ARIA とかスクリーンリーダー対応とかというよりは、キーボードユーザー対応でした (もちろん、`tabindex={-1}` を使用した `h2` へのフォーカスなどは、視覚情報がないユーザーに取っても有益な変更かと思います)。

編集中であることを示す `isEditing` があり、これが変更されたとき、編集中・非編集中それぞれでフォーカスしたい要素があり、ただし初回レンダリングではこれをしたくない、みたいな要件があり、今回は以下のように実装されていました。
1. state の前の値を返す `usePrevious` の作成
2. `const previousIsEditing = usePrevious(isEditing);`
3. `isEditing` の初期値は `false` なので、`isEditing` を deps とする `useEffect` で、`!isEditing` かつ `previousIsEditing` であるかどうかを評価する。

似たような要件で今までに以下のような実装をしたことがあるが、元の `isEditing` とは独立した state が一つ増えてしまうという点と、フォーカスの変更は実質的には単なる副作用なのに、メインロジックに結合してしまっているという点で、かなり良くない実装だなと思った。
`useEffect` をカオスにならないように使うのはなかなか難しいところもありますが、副作用の影響範囲が遠くには及ばず (例えば他の Recoil state の伝播的な変更など) 、明らかにメインロジックと関連がない場合に使うべきかもなと再認識した。

```ts
const [isEditing, setIsEditing] = useState(false);
const [hasChangedIsEditing, setHasChangedIsEditing] = useState(false);

const handleSubmit = () => {
  ...
  if (setHasChangedIsEditing) {
    focusFoo();
  }
  setIsEditing(false);
};

const turnToEditing = () => {
  setIsEditing(true);
  focusFoo();
  if (!hasChangedIsEditing) {
    setHasChangedIsEditing(true);
  }
};
```

(どうでもいいですがあまり `useRef` を使わないので、`usePrevious` の挙動の理解に3分くらいかけました)


